### PR TITLE
Change labels and transitions attr name, etc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,12 @@ python:
   - 3.5
 
 env:
-  - DJANGO=1.5
   - DJANGO=1.6
   - DJANGO=1.7
   - DJANGO=1.8
 
 matrix:
   exclude:
-    - python: 3.5
-      env: DJANGO=1.5
     - python: 3.5
       env: DJANGO=1.6
     - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,50 @@
+sudo: false
+
 language: python
 
 python:
   - 2.7
   - 3.3
   - 3.4
+  - 3.5
 
 env:
-  - DJANGO="Django>=1.5,<1.6"
-  - DJANGO="Django>=1.6,<1.7"
-  - DJANGO="Django>=1.7,<1.8"
-  - DJANGO="Django>=1.8,<1.9"
+  - DJANGO=1.5
+  - DJANGO=1.6
+  - DJANGO=1.7
+  - DJANGO=1.8
+
+matrix:
+  exclude:
+    - python: 3.5
+      env: DJANGO=1.5
+    - python: 3.5
+      env: DJANGO=1.6
+    - python: 3.5
+      env: DJANGO=1.7
+  include:
+    - python: 3.4
+      env: DJANGO=1.8  COVERAGE=true  COVERALLS_REPO_TOKEN=LdECqqwg7eelQx9w8gvooUZCFIaCqGZCv
+  allow_failures:
+    - env: COVERAGE=true
 
 install:
   - pip install flake8
-  - pip install -q $DJANGO
+  - pip install -q "Django>=$DJANGO,<$DJANGO.99"
   - make install
 
 script:
   - make flake8
-  - python run_tests.py
+  - make test
+
+after_script:
+  - if [ "$COVERAGE" == "true" ]; then
+    pip install --quiet python-coveralls;
+    make coverage;
+    coverage report;
+    coveralls --ignore-errors;
+    fi
 
 notifications:
   email:
     - hannes@5monkeys.se
-

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ test:
 	python setup.py test
 
 flake8:
-	flake8 --ignore=E501,F403 --max-complexity 12 django_enumfield
+	flake8 django_enumfield
 
 install:
 	python setup.py install
@@ -11,4 +11,4 @@ develop:
 	python setup.py develop
 
 coverage:
-	coverage run --include=django_enumfield/* setup.py test
+	coverage run --source django_enumfield setup.py test

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ You can use your own labels for Enum items
         CAT = 1
         DOG = 2
 
-        _labels = {
+        __labels__ = {
             CAT: 'Cat',
             DOG: 'Dog'
         }
@@ -67,7 +67,7 @@ The Enum-class provides the possibility to use transition validation.
         DEAD = 2
         REANIMATED = 3
 
-        _transitions = {
+        __transitions__ = {
             DEAD: (ALIVE,),
             REANIMATED: (DEAD,)
         }
@@ -97,7 +97,7 @@ The Enum-class can also be used without the EnumField. This is very useful in Dj
         MALE = 1
         FEMALE = 2
 
-        _labels = {
+        __labels__ = {
             MALE: 'Male',
             FEMALE: 'Female',
         }

--- a/README.rst
+++ b/README.rst
@@ -3,26 +3,11 @@ django-enumfield
 
 Provides an enumeration Django model field (using IntegerField) with reusable enums and transition validation.
 
-.. image:: https://travis-ci.org/5monkeys/django-enumfield.png?branch=master
+.. image:: https://travis-ci.org/5monkeys/django-enumfield.svg?branch=master
         :target: http://travis-ci.org/5monkeys/django-enumfield
 
-.. image:: https://pypip.in/d/django-enumfield/badge.png
-        :target: https://pypi.python.org/pypi/django-enumfield/
-
-.. image:: https://pypip.in/v/django-enumfield/badge.png
-        :target: https://pypi.python.org/pypi/django-enumfield/
-
-.. image:: https://pypip.in/egg/django-enumfield/badge.png
-        :target: https://pypi.python.org/pypi/django-enumfield/
-
-.. image:: https://pypip.in/wheel/django-enumfield/badge.png
-        :target: https://pypi.python.org/pypi/django-enumfield/
-
-.. image:: https://pypip.in/format/django-enumfield/badge.png
-        :target: https://pypi.python.org/pypi/django-enumfield/
-
-.. image:: https://pypip.in/license/django-enumfield/badge.png
-        :target: https://pypi.python.org/pypi/django-enumfield/
+.. image:: https://coveralls.io/repos/5monkeys/django-enumfield/badge.svg?branch=master&service=github
+        :target: https://coveralls.io/github/5monkeys/django-enumfield
 
 
 Installation

--- a/django_enumfield/db/fields.py
+++ b/django_enumfield/db/fields.py
@@ -3,12 +3,20 @@ from enum import Enum
 from django.db import models
 from django.utils.functional import curry
 from django.utils.encoding import force_text
+from django.utils import six
 from django import forms
+import django
 
-from django_enumfield import validators
+from .. import validators
 
 
-class EnumField(models.Field):
+if django.VERSION < (1, 8):
+    base = six.with_metaclass(models.SubfieldBase, models.Field)
+else:
+    base = models.Field
+
+
+class EnumField(base):
     """ EnumField is a convenience field to automatically handle validation of transitions
         between Enum values and set field choices from the enum.
         EnumField(MyEnum, default=MyEnum.INITIAL)

--- a/django_enumfield/db/fields.py
+++ b/django_enumfield/db/fields.py
@@ -85,6 +85,8 @@ class EnumField(base):
                 # First setattr no previous value on instance.
                 old_value = new_value
             # Update private enum attribute with new value
+            if new_value is not None and not isinstance(new_value, Enum):
+                new_value = enum.get(new_value)
             setattr(self, private_att_name, new_value)
             # Run validation for new value.
             validators.validate_valid_transition(enum, old_value, new_value)

--- a/django_enumfield/enum.py
+++ b/django_enumfield/enum.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from enum import Enum as NativeEnum
+from enum import IntEnum as NativeIntEnum
 
 import logging
 
@@ -21,7 +22,7 @@ class BlankEnum(NativeEnum):
         return ''
 
 
-class Enum(NativeEnum):
+class Enum(NativeIntEnum):
     """ A container for holding and restoring enum values """
 
     __labels__ = {}

--- a/django_enumfield/enum.py
+++ b/django_enumfield/enum.py
@@ -53,7 +53,8 @@ class Enum(NativeEnum):
         return super(Enum, self).__eq__(other)
 
     def __hash__(self):
-        return hash(self.deconstruct())
+        path, (val,), _ = self.deconstruct()
+        return hash('{}.{}'.format(path, val))
 
     def deconstruct(self):
         """

--- a/django_enumfield/tests/__init__.py
+++ b/django_enumfield/tests/__init__.py
@@ -1,1 +1,0 @@
-from django_enumfield.tests.test_enum import *

--- a/django_enumfield/tests/models.py
+++ b/django_enumfield/tests/models.py
@@ -21,7 +21,7 @@ class PersonStatus(Enum):
     REANIMATED = 3
     VOID = 4
 
-    _transitions = {
+    __transitions__ = {
         UNBORN: (VOID,),
         ALIVE: (UNBORN,),
         DEAD: (UNBORN, ALIVE),
@@ -59,7 +59,7 @@ class LabelBeer(Enum):
     JUPILER = 1
     TYSKIE = 2
 
-    _labels = {
+    __labels__ = {
         STELLA: _('Stella Artois'),
         TYSKIE: _('Browar Tyskie'),
     }

--- a/django_enumfield/tests/test_enum.py
+++ b/django_enumfield/tests/test_enum.py
@@ -168,3 +168,6 @@ class EnumTest(TestCase):
         self.assertTrue(isinstance(LabelBeer.STELLA.label, six.string_types))
         self.assertEqual(LabelBeer.STELLA.label,
                          six.text_type('Stella Artois'))
+
+    def test_hash(self):
+        self.assertTrue({LabelBeer.JUPILER: True}[LabelBeer.JUPILER])

--- a/django_enumfield/tests/test_enum.py
+++ b/django_enumfield/tests/test_enum.py
@@ -3,7 +3,6 @@ from django.db import IntegrityError
 from django.forms import ModelForm, TypedChoiceField
 from django.test import TestCase
 from django.utils import six
-import django
 
 from django_enumfield.db.fields import EnumField
 from django_enumfield.enum import Enum, BlankEnum
@@ -45,11 +44,8 @@ class EnumFieldTest(TestCase):
 
         person = Person.objects.get(pk=pk)
         self.assertEqual(person.status, PersonStatus.DEAD)
-        if django.VERSION < (1, 8):
-            # SubfieldBase seems not using .to_python() on model initialiation
-            self.assertTrue(isinstance(person.status, int))
-        else:
-            self.assertTrue(isinstance(person.status, PersonStatus))
+        self.assertTrue(isinstance(person.status, int))
+        self.assertTrue(isinstance(person.status, PersonStatus))
 
         self.assertRaises(InvalidStatusOperationError, setattr, person, 'status', 99)
 

--- a/django_enumfield/tests/test_enum.py
+++ b/django_enumfield/tests/test_enum.py
@@ -5,9 +5,10 @@ from django.test import TestCase
 from django.utils import six
 
 from django_enumfield.db.fields import EnumField
-from django_enumfield.enum import Enum
+from django_enumfield.enum import Enum, BlankEnum
 from django_enumfield.exceptions import InvalidStatusOperationError
-from django_enumfield.tests.models import Person, PersonStatus, Lamp, LampState, Beer, BeerStyle, BeerState
+from django_enumfield.tests.models import Person, PersonStatus, Lamp, \
+    LampState, Beer, BeerStyle, BeerState, LabelBeer
 
 
 class EnumFieldTest(TestCase):
@@ -21,7 +22,7 @@ class EnumFieldTest(TestCase):
         self.assertEqual(field.default, None)
 
     def test_enum_field_save(self):
-        # Test model with EnumField WITHOUT _transitions
+        # Test model with EnumField WITHOUT __transitions__
 
         lamp = Lamp.objects.create()
         self.assertEqual(lamp.state, LampState.OFF)
@@ -32,16 +33,19 @@ class EnumFieldTest(TestCase):
 
         self.assertRaises(InvalidStatusOperationError, setattr, lamp, 'state', 99)
 
-        # Test model with EnumField WITH _transitions
+        # Test model with EnumField WITH __transitions__
         person = Person.objects.create()
         pk = person.pk
         self.assertEqual(person.status, PersonStatus.ALIVE)
         person.status = PersonStatus.DEAD
         person.save()
+        self.assertTrue(isinstance(person.status, PersonStatus))
         self.assertEqual(person.status, PersonStatus.DEAD)
 
         person = Person.objects.get(pk=pk)
         self.assertEqual(person.status, PersonStatus.DEAD)
+        # TODO: find a way to get only one type
+        self.assertTrue(isinstance(person.status, (PersonStatus, int)))
 
         self.assertRaises(InvalidStatusOperationError, setattr, person, 'status', 99)
 
@@ -120,8 +124,14 @@ class EnumFieldTest(TestCase):
 
 
 class EnumTest(TestCase):
+    def test_label(self):
+        self.assertEqual(PersonStatus.ALIVE.label, six.text_type('ALIVE'))
+        self.assertEqual(LabelBeer.STELLA.label,
+                         six.text_type('Stella Artois'))
+
     def test_name(self):
         self.assertEqual(PersonStatus.ALIVE.name, six.text_type('ALIVE'))
+        self.assertEqual(LabelBeer.STELLA.name, six.text_type('STELLA'))
 
     def test_get(self):
         self.assertTrue(isinstance(PersonStatus.get(PersonStatus.ALIVE), Enum))
@@ -129,8 +139,13 @@ class EnumTest(TestCase):
         self.assertEqual(PersonStatus.get(PersonStatus.ALIVE), PersonStatus.get(six.text_type('ALIVE')))
 
     def test_choices(self):
-        self.assertEqual(len(PersonStatus.choices()), len(list(PersonStatus.items())))
-        self.assertTrue(all(key in PersonStatus.__members__ for key in dict(list(PersonStatus.items()))))
+        self.assertEqual(len(PersonStatus.choices()), len(PersonStatus))
+        for value, member in PersonStatus.choices():
+            self.assertTrue(isinstance(value, int))
+            self.assertTrue(isinstance(member, PersonStatus))
+            self.assertTrue(PersonStatus.get(value) == member)
+        blank = PersonStatus.choices(blank=True)[0]
+        self.assertEqual(blank, (BlankEnum.BLANK.value, BlankEnum.BLANK))
 
     def test_default(self):
         self.assertEqual(PersonStatus.default(), PersonStatus.UNBORN)
@@ -142,3 +157,10 @@ class EnumTest(TestCase):
         self.assertTrue(PersonStatus.ALIVE == PersonStatus.ALIVE)
         self.assertFalse(PersonStatus.ALIVE == PersonStatus.DEAD)
         self.assertEqual(PersonStatus.get(PersonStatus.ALIVE), PersonStatus.get(PersonStatus.ALIVE))
+
+    def test_labels(self):
+        self.assertEqual(LabelBeer.JUPILER.name, LabelBeer.JUPILER.label)
+        self.assertNotEqual(LabelBeer.STELLA.name, LabelBeer.STELLA.label)
+        self.assertTrue(isinstance(LabelBeer.STELLA.label, six.string_types))
+        self.assertEqual(LabelBeer.STELLA.label,
+                         six.text_type('Stella Artois'))

--- a/django_enumfield/tests/test_enum.py
+++ b/django_enumfield/tests/test_enum.py
@@ -3,6 +3,7 @@ from django.db import IntegrityError
 from django.forms import ModelForm, TypedChoiceField
 from django.test import TestCase
 from django.utils import six
+import django
 
 from django_enumfield.db.fields import EnumField
 from django_enumfield.enum import Enum, BlankEnum
@@ -44,8 +45,11 @@ class EnumFieldTest(TestCase):
 
         person = Person.objects.get(pk=pk)
         self.assertEqual(person.status, PersonStatus.DEAD)
-        # TODO: find a way to get only one type
-        self.assertTrue(isinstance(person.status, (PersonStatus, int)))
+        if django.VERSION < (1, 8):
+            # SubfieldBase seems not using .to_python() on model initialiation
+            self.assertTrue(isinstance(person.status, int))
+        else:
+            self.assertTrue(isinstance(person.status, PersonStatus))
 
         self.assertRaises(InvalidStatusOperationError, setattr, person, 'status', 99)
 

--- a/django_enumfield/tests/test_validators.py
+++ b/django_enumfield/tests/test_validators.py
@@ -19,7 +19,7 @@ class ValidatorTest(unittest.TestCase):
         """Test passing an int as a string validation
         """
         self.assertIsNone(
-            validate_available_choice(BeerStyle, '%s' % BeerStyle.LAGER)
+            validate_available_choice(BeerStyle, '%s' % BeerStyle.LAGER.value)
         )
 
     def test_validate_available_choice_3(self):

--- a/django_enumfield/validators.py
+++ b/django_enumfield/validators.py
@@ -5,7 +5,6 @@ from django.utils.translation import gettext as _
 from django.utils import six
 
 from django_enumfield.exceptions import InvalidStatusOperationError
-from django.utils.encoding import force_text
 
 
 def validate_valid_transition(enum, from_value, to_value):
@@ -23,7 +22,7 @@ def validate_valid_transition(enum, from_value, to_value):
     else:
         f_value = from_value
 
-    if hasattr(enum, '_transitions') and not enum.is_valid_transition(f_value, t_value):
+    if not enum.is_valid_transition(f_value, t_value):
         message = _(six.text_type('{enum} can not go from "{from_value}" to "{to_value}"'))
         raise InvalidStatusOperationError(message.format(
             enum=enum.__name__,
@@ -39,16 +38,4 @@ def validate_available_choice(enum, to_value):
     if to_value is None:
         return
 
-    if isinstance(to_value, Enum):
-        to_value = to_value.value
-
-    if isinstance(to_value, six.string_types):
-        for member in enum:
-            if force_text(member) == to_value:
-                to_value = member.value
-                break
-
-    member_values = [member.value for member in enum]
-    if to_value not in member_values:
-        message = _(six.text_type('Select a valid choice. {value} is not one of the available choices.'))
-        raise InvalidStatusOperationError(message.format(value=to_value))
+    enum.get(to_value)

--- a/run_tests.py
+++ b/run_tests.py
@@ -30,6 +30,7 @@ def main():
             ROOT_URLCONF='django_enumfield.tests.urls',
             DEBUG=True,
             TEMPLATE_DEBUG=True,
+            MIDDLEWARE_CLASSES=[],
         )
 
     # Compatibility with Django 1.7's stricter initialization

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,9 @@ universal = 1
 
 [extras]
 enum34:python_version>"2.7";:python_version<"3.4"
+
+[flake8]
+exclude = .tox,.git,docs,migrations
+ignore = F403
+max-complexity = 12
+max-line-length = 110

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,5 @@ enum34:python_version>"2.7";:python_version<"3.4"
 
 [flake8]
 exclude = .tox,.git,docs,migrations
-ignore = F403
 max-complexity = 12
 max-line-length = 110


### PR DESCRIPTION
...use enum instead of int in field value; raise validation error when enum is not found by value or name (and support digit str), etc

WARNING: Inconsistent field value atm -- enum for Django 1.8 and int for other versions when model is initialized
